### PR TITLE
enable custom css modules compilers

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,7 @@ Currently supported and possible future features (in no particular order) are:
  - [x] Easy localization with vue-i18n out-of-the-box integration, auto-detection, server-side injection and key-in-hand ui ![vue](https://img.shields.io/badge/vue-1.x-green.svg)
  - [x] Easy state management with vuex integration ![vue](https://img.shields.io/badge/vue-1.x-green.svg)
  - [x] Use Blaze templates in your vue app ![vue](https://img.shields.io/badge/vue-1.x-green.svg) ![vue](https://img.shields.io/badge/vue-2.x-brightgreen.svg)
+ - [x] `module` attribute on `<style>` in .vue files
  - [ ] *Typescript official integration in .vue files*
  - [ ] *Server-side rendering (Vue 2.x)*
  - [ ] *`src` attribute support in `.vue` files*

--- a/packages/vue-component/README.md
+++ b/packages/vue-component/README.md
@@ -98,11 +98,6 @@ As an alternative to scoped styles, you can use CSS modules to scope your CSS to
 
 Note: composing from other files is not supported by the built-in CSS modules processor. See the community packages.
 
-Community packages:
-
-- [nathantreid:vue-css-modules](https://github.com/nathantreid/vue-css-modules) enables interop with nathantreid:css-modules, including support for composing from other files.
-
-
 ### Language packages
 
 Using the power of preprocessors, you can use a different language (like less or jade) by adding a `lang` attribute on your `<template>`, `<script>` or `<style>` tags.
@@ -122,6 +117,9 @@ Official packages for `<style>` tag:
  - [akryum:vue-stylus](https://github.com/Akryum/meteor-vue-component/tree/master/packages/vue-stylus)
 
 Community packages welcomed (add a your package with a PR)!
+Community packages for `<style>` tag:
+
+ - [nathantreid:vue-css-modules](https://github.com/nathantreid/vue-css-modules) enables interop with nathantreid:css-modules, including support for composing from other files.
 
 ### Manual import
 

--- a/packages/vue-component/README.md
+++ b/packages/vue-component/README.md
@@ -72,6 +72,37 @@ a {
 </style>
 ```
 
+### CSS Modules
+
+As an alternative to scoped styles, you can use CSS modules to scope your CSS to your components by adding the `module` attribute to any `<style>` tag in your component file and accessing the styles via the `$style` property:
+```html
+<style module>
+/* Will only be applied to this component <a> elements */
+.red {
+   color: red;
+}
+</style>
+
+<template>
+  <div :class="$style.red">Red Text</div>
+</template>
+
+<script>
+  export default {
+    created() {
+      console.log(this.$style.red);
+    }
+  }
+</script>
+```
+
+Note: composing from other files is not supported by the built-in CSS modules processor. See the community packages.
+
+Community packages:
+
+- [nathantreid:vue-css-modules](https://github.com/nathantreid/vue-css-modules) enables interop with nathantreid:css-modules, including support for composing from other files.
+
+
 ### Language packages
 
 Using the power of preprocessors, you can use a different language (like less or jade) by adding a `lang` attribute on your `<template>`, `<script>` or `<style>` tags.

--- a/packages/vue-component/plugin/vue-compiler.js
+++ b/packages/vue-component/plugin/vue-compiler.js
@@ -613,7 +613,6 @@ function generateJs (vueId, inputFile, compileResult, isHotReload = false) {
 
   // CSS Modules
   if(compileResult.cssModules) {
-    console.log('adding css modules', JSON.stringify(compileResult.cssModules))
     const modulesCode = '__vue_options__.computed = __vue_options__.computed || {};\n' +
      `__vue_options__.computed.$style = function() {\n return ${JSON.stringify(compileResult.cssModules)}\n};\n`;
     js += modulesCode;


### PR DESCRIPTION
I'd like to add support for custom CSS modules compilers similar to your support for custom "lang" processors. If there is no custom processor, it defaults to the basic processor I added in #117.
The main reason for this PR is so I can interop with my css-modules build compiler, allowing the user to import other CSS modules files and use all of the configuration options I provide.

The compile call is identical to the one for lang compilers with the addition of passing in the `styleTag` and sourcemap. I pass in the `styleTag` because I need to set the `autoprefix` attribute to `off` if the user is already using autoprefixer through my package as well as read the `module` attribute so I can implement support for multiple style tags. _I'll need to make another PR eventually since the module attribute should also allow [overriding the computed property name](http://vue-loader.vuejs.org/en/features/css-modules.html)._

You'll also note that in handling the result I append to the `js` variable - this is because CSS modules reference other files via composes (as opposed to including them in the source like sass imports). My plugin therefore outputs `require` statements so Meteor will load those referenced files.

I wasn't sure how exactly you'd want the cssModules compiler to be specified so for now I used `global.vue.cssModules`.