### PR TITLE
Sass imports

### DIFF
--- a/packages/vue-sass/package.js
+++ b/packages/vue-sass/package.js
@@ -15,7 +15,8 @@ Package.registerBuildPlugin({
       'vue-sass.js'
   ],
   npmDependencies: {
-    'node-sass': '3.7.0'
+    'node-sass': '3.7.0',
+    'meteor-project-path': '0.0.1'
   }
 });
 

--- a/packages/vue-sass/vue-sass.js
+++ b/packages/vue-sass/vue-sass.js
@@ -5,6 +5,7 @@ import path from 'path';
 import fs from 'fs';
 import sass from 'node-sass';
 import {Meteor} from 'meteor/meteor';
+import meteorProjectPath from 'meteor-project-path';
 
 function resolveImport(dependencyManager) {
   return function (url, prev, done) {
@@ -15,7 +16,7 @@ function resolveImport(dependencyManager) {
     /*} else if (url.indexOf('{') === 0) {
       resolvedFilename = decodeFilePath(url);*/
     } else if (url.indexOf('/') === 0) {
-      resolvedFilename = process.cwd() + url;
+      resolvedFilename = meteorProjectPath + url;
     } else {
       let currentDirectory = path.dirname(this.options.outFile);
       resolvedFilename = path.resolve(currentDirectory, url);

--- a/packages/vue-sass/vue-sass.js
+++ b/packages/vue-sass/vue-sass.js
@@ -14,6 +14,8 @@ function resolveImport(dependencyManager) {
       resolvedFilename = url.substr(1);
     /*} else if (url.indexOf('{') === 0) {
       resolvedFilename = decodeFilePath(url);*/
+    } else if (url.indexOf('/') === 0) {
+      resolvedFilename = process.cwd() + url;
     } else {
       let currentDirectory = path.dirname(this.options.outFile);
       resolvedFilename = path.resolve(currentDirectory, url);

--- a/packages/vue-sass/vue-sass.js
+++ b/packages/vue-sass/vue-sass.js
@@ -21,7 +21,8 @@ function resolveImport(dependencyManager) {
       resolvedFilename = path.resolve(currentDirectory, url);
     }
 
-    if (!fs.existsSync(resolvedFilename)) {
+    resolvedFilename = discoverImportPath(resolvedFilename);
+    if (resolvedFilename === null) {
       done(new Error('Unknown import (file not found): ' + url));
     } else {
       dependencyManager.addDependency(resolvedFilename);
@@ -31,6 +32,26 @@ function resolveImport(dependencyManager) {
       });
     }
   };
+}
+
+function discoverImportPath(importPath) {
+  const potentialPaths = [importPath];
+  const potentialFileExtensions = ["scss", "sass"];
+
+  if (!path.extname(importPath)) {
+    potentialFileExtensions.forEach(extension => potentialPaths.push(`${importPath}.${extension}`));
+  }
+  if (path.basename(importPath)[0] !== '_') {
+    [].concat(potentialPaths).forEach(potentialPath => potentialPaths.push(`${path.dirname(potentialPath)}/_${path.basename(potentialPath)}`));
+  }
+
+  for (let i = 0, potentialPath = potentialPaths[i]; i < potentialPaths.length; i++, potentialPath = potentialPaths[i]) {
+    if (fs.existsSync(potentialPaths[i]) && fs.lstatSync(potentialPaths[i]).isFile()) {
+      return potentialPath;
+    }
+  }
+
+  return null;
 }
 
 function decodeFilePath(filePath) {

--- a/packages/vue-sass/vue-sass.js
+++ b/packages/vue-sass/vue-sass.js
@@ -9,6 +9,7 @@ import {Meteor} from 'meteor/meteor';
 function resolveImport(dependencyManager) {
   return function (url, prev, done) {
     let resolvedFilename;
+    url = url.replace(/^["']?(.*?)["']?$/, '$1');
     if (url.indexOf('~') === 0) {
       resolvedFilename = url.substr(1);
     /*} else if (url.indexOf('{') === 0) {


### PR DESCRIPTION
This addresses the import issue in #76 (imports without file extensions).
If an import is given without a file extension, we will try to find it first as is, then with the .scss extension, then the .sass extension.
If none of those match and the filename didn't start with a `_`, we try again after adding the underscore prefix.
Given the import `@import "foo";`, we will look at the following paths:
```
foo
foo.scss
foo.sass
_foo
_foo.scss
_foo.sass
```

In addition, this PR enables leading slash imports as relative to the Meteor project directory, so `@import "/imports/test.scss"` will be relative to your project instead of your file system.