### PR TITLE
Add exception to lang="html" as template tag

### DIFF
--- a/packages/vue-component/plugin/tag-handler.js
+++ b/packages/vue-component/plugin/tag-handler.js
@@ -198,7 +198,7 @@ VueComponentTagHandler = class VueComponentTagHandler {
       template = templateTag.contents;
 
       // Lang
-      if (templateTag.attribs.lang !== undefined) {
+      if (templateTag.attribs.lang !== undefined && templateTag.attribs.lang !== "html") {
         let lang = templateTag.attribs.lang;
         try {
           let compile = global.vue.lang[lang];


### PR DESCRIPTION
Hi, can we add this exception to language type html in template tag? This is because some plugin still use lang="html" although it is same as not using any tag.

For example:

[https://github.com/gluons/vue-highlight.js/blob/master/src/highlight-code.vue](https://github.com/gluons/vue-highlight.js/blob/master/src/highlight-code.vue)