### PR TITLE
Add support for customizing the name of the CSS modules property via the module attribute

### DIFF
--- a/packages/vue-component/README.md
+++ b/packages/vue-component/README.md
@@ -96,6 +96,26 @@ As an alternative to scoped styles, you can use CSS modules to scope your CSS to
 </script>
 ```
 
+By default, your styles will be assigned to the `$style` computed property. You can customize this by setting the module attribute. This also allows you to create multiple "modules" in one component file:
+
+```html
+<style module="foo">
+  .color {
+    color: orange;
+  }
+</style>
+<style module="bar">
+  .color {
+    color: purple;
+  }
+</style>
+
+<template>
+  <div :class="foo.color">Foo Text</div>
+  <div :class="bar.color">Bar Text</div>
+</template>
+```
+
 Note: composing from other files is not supported by the built-in CSS modules processor. See the community packages.
 
 ### Language packages

--- a/packages/vue-component/plugin/vue-compiler.js
+++ b/packages/vue-component/plugin/vue-compiler.js
@@ -582,10 +582,11 @@ function generateJs (vueId, inputFile, compileResult, isHotReload = false) {
 
   // CSS Modules
   if(compileResult.cssModules) {
+    const modules = Object.keys(compileResult.cssModules);
     const modulesCode = '__vue_options__.computed = __vue_options__.computed || {};\n' +
-     `__vue_options__.computed.$style = function() {\n return ${JSON.stringify(compileResult.cssModules)}\n};\n`;
+      modules.map(module=>`__vue_options__.computed['${module}'] = function() {\n return ${JSON.stringify(compileResult.cssModules[module])}\n};\n`).join('\n');
     js += modulesCode;
-    console.log(modulesCode)
+    // console.log(modulesCode);
   }
 
   // Package context


### PR DESCRIPTION
The default variable name (unchanged) is `$style`. Now, the user can control this, and even have separate modules, by setting the value of the module attribute (copying the code example from the updated documentation):

```html
<style module="foo">
  .color {
    color: orange;
  }
</style>
<style module="bar">
  .color {
    color: purple;
  }
</style>

<template>
  <div :class="foo.color">Foo Text</div>
  <div :class="bar.color">Bar Text</div>
</template>
```

I think that's the last step to put this on par with vue-loader's CSS modules capability.