### PR TITLE
Pass all CoffeeScript compiler output through Babel

### DIFF
--- a/packages/vue-coffee/package.js
+++ b/packages/vue-coffee/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   name: 'akryum:vue-coffee',
-  version: '0.0.3',
+  version: '0.0.4',
   summary: 'Add coffee support for vue components',
   git: 'https://github.com/Akryum/meteor-vue-component',
   documentation: 'README.md'
@@ -15,7 +15,7 @@ Package.registerBuildPlugin({
     'vue-coffee.js'
   ],
   npmDependencies: {
-    'coffee-script': '1.12.1',
+    'coffee-script': '1.12.4',
     'source-map': '0.5.6'
   }
 });

--- a/packages/vue-coffee/vue-coffee.js
+++ b/packages/vue-coffee/vue-coffee.js
@@ -33,12 +33,9 @@ global.vue.lang.coffee = Meteor.wrapAsync(function({
 
   let output = coffee.compile(source, compileOptions);
 
-  if (source.indexOf('`') !== -1) {
-    // If source contains backticks, pass the coffee output through ecmascript
-    try {
-      output.js = ECMAScript.compileForShell(output.js);
-    } catch (e) {}
-  }
+  try {
+    output.js = ECMAScript.compileForShell(output.js);
+  } catch (e) {}
 
   const stripped = stripExportedVars(
     output.js,


### PR DESCRIPTION
This PR changes `vue-coffee` to pass *all* CoffeeScript compiler output through Babel, not just when backticks are present. This allows support for CoffeeScript opt-in ES2015 features like modules and generators.

Once this PR is merged in, there will no longer be a need for wrapping [`import` or `export` statements](http://coffeescript.org/#modules) in backticks.

Closes #96.