### PR TITLE
Fix Sass error on empty <style>

### DIFF
--- a/packages/vue-sass/vue-sass.js
+++ b/packages/vue-sass/vue-sass.js
@@ -70,6 +70,10 @@ global.vue.lang.scss = Meteor.wrapAsync(function({
   inputFile,
   dependencyManager
 }, cb) {
+  if (!source.trim()) {
+    cb(null, { css: ''});
+    return;
+  }
   sass.render({
     data: source,
     importer: resolveImport(dependencyManager),
@@ -93,6 +97,10 @@ global.vue.lang.sass = Meteor.wrapAsync(function({
   inputFile,
   dependencyManager
 }, cb) {
+  if (!source.trim()) {
+    cb(null, { css: ''});
+    return;
+  }
   sass.render({
     data: source,
     importer: resolveImport(dependencyManager),


### PR DESCRIPTION
Some of the latest changes have caused empty `<style>` tags to throw errors. I'm guessing it was caused by https://github.com/Akryum/vue-meteor/commit/68c026d482c0c9fa2c4aa6175764a0f8417988de.
Anyways, after updating from 0.8.15 to the latest, attempting to compile a file with an empty style tag, like either of the following examples, results in the error shown below. This PR addresses this by not preprocessing empty sass/scss files.
I didn't want to completely skip processing all empty `<style>` tags in `tag-handler.js` in case someone created a preprocessor that added content even if the style tag was empty, so I made the adjustment in `vue-sass` instead.

``` html
<style lang="scss"></style>

<style lang="scss">

</style>
```

```
Compiling <style> in lang scss...
[vue-component] Error while compiling in tag <style> using lang scss -> in SomeFile.vue
{ status: 3,
  message: 'No input specified: provide a file name or a source string to process' }
```