### PR TITLE
Fix CSS modules in 0.8.18

### DIFF
--- a/packages/vue-component/plugin/tag-handler.js
+++ b/packages/vue-component/plugin/tag-handler.js
@@ -313,7 +313,7 @@ VueComponentTagHandler = class VueComponentTagHandler {
         // CSS Modules
         let isAsync = false;
         let defaultModuleName = '$style';
-        if (styleTag.attribs.module) {
+        if ('module' in styleTag.attribs && !!css.trim()) {
           if (global.vue.cssModules) {
             try {
               let compile = global.vue.cssModules;


### PR DESCRIPTION
Some of the latest changes changed the module attributes without a value are reported (they are now `undefined`) and also caused some files to be completely empty, which (similar to node-sass) causes issues with CSS modules.
This PR fixes detection of the `module` attribute and skips CSS module processing if the `<style>` tag is empty.