### PR TITLE
Update CoffeeScript

### DIFF
--- a/.meteor/versions
+++ b/.meteor/versions
@@ -1,10 +1,10 @@
 accounts-base@1.2.14
 akryum:npm-check@0.0.3
 akryum:vue@1.2.2
-akryum:vue-coffee@0.0.3
 akryum:vue-compiler@2.1.10
 akryum:vue-component@0.8.7
 akryum:vue-component-dev-client@0.2.5
+akryum:vue-coffee@0.0.5
 akryum:vue-component-dev-server@0.0.5
 akryum:vue-i18n@0.0.5
 akryum:vue-i18n-ui@0.0.5

--- a/client/ui/Post.vue
+++ b/client/ui/Post.vue
@@ -5,16 +5,15 @@
 </template>
 
 <script lang="coffee">
-`import {Meteor} from 'meteor/meteor'`
+import { Meteor } from 'meteor/meteor'
 
-return {
+return
   props: [ 'data' ]
   methods:
     removePost: ->
       Meteor.call 'posts.remove', @data._id
   created:
     console.log 'Post'
-}
 </script>
 
 <!-- Project path test -->

--- a/packages/vue-coffee/README.md
+++ b/packages/vue-coffee/README.md
@@ -13,14 +13,13 @@ This meteor package adds [coffee-script](http://coffeescript.org/) support in yo
 
 ```html
 <script lang="coffee">
-`import {Meteor} from 'meteor/meteor'`
+import { Meteor } from 'meteor/meteor'
 
-return {
+return
   props: [ 'data' ]
-  methods: removePost: ->
-    Meteor.call 'posts.remove', @data._id
-    return
-}
+  methods:
+    removePost: ->
+      Meteor.call 'posts.remove', @data._id
 </script>
 ```
 

--- a/packages/vue-coffee/README.md
+++ b/packages/vue-coffee/README.md
@@ -1,8 +1,8 @@
-# Integrate coffee-script with vue single-file components for Meteor
+# Integrate CoffeeScript with vue single-file components for Meteor
 
 Compatibility: **Vue 1.x, Vue 2.x**
 
-This meteor package adds [coffee-script](http://coffeescript.org/) support in your single-file `.vue` components.
+This meteor package adds [CoffeeScript](http://coffeescript.org/) support in your single-file `.vue` components.
 
 ## Installation
 

--- a/packages/vue-coffee/package.js
+++ b/packages/vue-coffee/package.js
@@ -15,7 +15,7 @@ Package.registerBuildPlugin({
     'vue-coffee.js'
   ],
   npmDependencies: {
-    'coffee-script': '1.12.6',
+    'coffeescript': '1.12.6',
     'source-map': '0.5.6'
   }
 });

--- a/packages/vue-coffee/package.js
+++ b/packages/vue-coffee/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   name: 'akryum:vue-coffee',
-  version: '0.0.4',
+  version: '0.0.5',
   summary: 'Add coffee support for vue components',
   git: 'https://github.com/Akryum/meteor-vue-component',
   documentation: 'README.md'
@@ -15,7 +15,7 @@ Package.registerBuildPlugin({
     'vue-coffee.js'
   ],
   npmDependencies: {
-    'coffee-script': '1.12.4',
+    'coffee-script': '1.12.6',
     'source-map': '0.5.6'
   }
 });

--- a/packages/vue-coffee/vue-coffee.js
+++ b/packages/vue-coffee/vue-coffee.js
@@ -4,11 +4,11 @@ global.vue = global.vue || {}
 global.vue.lang = global.vue.lang || {}
 
 
-import sourcemap from "source-map";
-import coffee from "coffee-script";
+import sourcemap from 'source-map';
+import coffee from 'coffeescript';
 import {
   ECMAScript
-} from "meteor/ecmascript";
+} from 'meteor/ecmascript';
 import {
   Meteor
 } from 'meteor/meteor';


### PR DESCRIPTION
Updates CoffeeScript to 1.12.6, which removes the need for `{` after `return` or `export default`, making for more idiomatic code for the most common Vue pattern (see updated examples).